### PR TITLE
Hotfix secure cookie

### DIFF
--- a/components/LoginView/LoginView.tsx
+++ b/components/LoginView/LoginView.tsx
@@ -37,11 +37,7 @@ const LoginView: React.FC<ILoginView> = ({  }) => {
 
                     Cookies.set(
                       process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME,
-                      JSON.stringify(login_storage), // secure flag option must be added in the future
-                      {
-                        secure: true,
-                        httpOnly: true
-                      }
+                      JSON.stringify(login_storage) // secure flag option must be added in the future
                     );
                     
                     Router.push("/dash")


### PR DESCRIPTION
quitamos momentáneamente las flags secure y http only para la cookie de loggeo
