### PR TITLE
Feature/fix qr cookie

### DIFF
--- a/constants/ index.ts
+++ b/constants/ index.ts
@@ -1,1 +1,2 @@
 export const API_URL = process.env.NEXT_PUBLIC_API_SENDER_URL;
+export const LOGIN_COOKIE = process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME;

--- a/middleware.ts
+++ b/middleware.ts
@@ -26,7 +26,6 @@ export async function middleware(req: NextRequest) {
     } else {
       const accessToken = JSON.parse(authenticated.value).access_token;
       headers.append("Authorization", `Bearer ${accessToken}`);
-      console.log("asdf", process.env.NEXT_PUBLIC_API_USER_URL)
       const apiResponse = await fetch(
         `${process.env.NEXT_PUBLIC_API_USER_URL}/ws`,
         { headers }

--- a/middleware.ts
+++ b/middleware.ts
@@ -26,15 +26,16 @@ export async function middleware(req: NextRequest) {
     } else {
       const accessToken = JSON.parse(authenticated.value).access_token;
       headers.append("Authorization", `Bearer ${accessToken}`);
+      console.log("asdf", process.env.NEXT_PUBLIC_API_USER_URL)
       const apiResponse = await fetch(
         `${process.env.NEXT_PUBLIC_API_USER_URL}/ws`,
         { headers }
       );
-      
+
       const data = await apiResponse.json();
       const isWhatsAppConnected = data.data.connected_whatsapp;
-     
-      
+
+
       if (!isWhatsAppConnected) {
         if (requestedPage !== "/qr" && requestedPage !== "/user/edit") {
           url.pathname = "/qr";

--- a/pages/dash.tsx
+++ b/pages/dash.tsx
@@ -1,62 +1,58 @@
+import cookie from 'cookie';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { mockCardsContProps } from '../components/cards/CardsCont.mocks';
-import CardsCont from '../components/cards/CardsContFree';
 import { IEditUserProfileView } from '../components/EditUserProfileView/EditUserProfileView';
 import Header from '../components/Header/Header';
+import { mockCardsContProps } from '../components/cards/CardsCont.mocks';
+import CardsCont from '../components/cards/CardsContFree';
 import PrimaryLayout from '../components/layouts/primary/PrimaryLayout';
 import { NextPageWithLayout } from './page';
 import EditUserProfile from './user/edit';
 
 
-
-
-const Home: NextPageWithLayout<IEditUserProfileView> = ({user}) => {
-
-  const { locale } = useRouter();
+const Home: NextPageWithLayout<IEditUserProfileView> = ({ user }) => {
   const [openSettings, setOpenSettings] = useState<boolean>(false)
-  
+
   return (
-    <section style={{'position':'relative', 'height':'100%', 'width':'100%'}}>
+    <section style={{ 'position': 'relative', 'height': '100%', 'width': '100%' }}>
       <Header openSettings={openSettings} setOpenSettings={setOpenSettings} />
 
       <AnimatePresence>
-      {!openSettings && (
-        <motion.div
-        key="dash-cont"
-        initial={{ opacity: 0, translateY : 15 }}
-        animate={{ opacity: 1 , translateY : 0 , transition : {delay : 0.7} }}
-        exit={{ opacity: 0, translateY : 15  }}
-        style={{ position: 'absolute' }}
-        >
-             <div  style={{
-               'width' : '100vw',
-               'height' : '100vh',
-               'position': 'relative'
-              }}
-              >
+        {!openSettings && (
+          <motion.div
+            key="dash-cont"
+            initial={{ opacity: 0, translateY: 15 }}
+            animate={{ opacity: 1, translateY: 0, transition: { delay: 0.7 } }}
+            exit={{ opacity: 0, translateY: 15 }}
+            style={{ position: 'absolute' }}
+          >
+            <div style={{
+              'width': '100vw',
+              'height': '100vh',
+              'position': 'relative'
+            }}
+            >
               <CardsCont {...mockCardsContProps.base} />
 
             </div>
-      </motion.div>
-      )}
-      {openSettings && (
+          </motion.div>
+        )}
+        {openSettings && (
           <motion.div
             key="settings-cont"
-            initial={{ opacity: 0, scale : 0.5 }}
-            animate={{ opacity: 1 , scale : 1 , transition : {delay : 0.7} }}
-            exit={{ opacity: 0, scale : 0.5  }}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1, transition: { delay: 0.7 } }}
+            exit={{ opacity: 0, scale: 0.5 }}
             transition={{ duration: 0.5 }}
           >
-            <div  style={{
-                'width' : '100vw',
-                'height' : '100vh',
-                'position': 'relative',
-                'marginTop': '5%'
-              }}
+            <div style={{
+              'width': '100vw',
+              'height': '100vh',
+              'position': 'relative',
+              'marginTop': '5%'
+            }}
             >
-              <EditUserProfile user={user}/>
+              <EditUserProfile user={user} />
             </div>
           </motion.div>
         )}
@@ -70,33 +66,32 @@ const Home: NextPageWithLayout<IEditUserProfileView> = ({user}) => {
 
 export default Home;
 
+Home.getInitialProps = async (context) => {
+  if (context.req?.headers.cookie) {
+    const cookies = cookie.parse(context.req.headers.cookie);
+    const { access_token: accessToken } = JSON.parse(cookies[process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME || '']);
 
-
-export async function getServerSideProps(context) {
-  const cookies = context.req?.cookies;
-  const headers = new Headers({
-      "Content-Type": "application/json",
-      });
-  const cookieName = process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME
-  const accessToken = JSON.parse(cookies[`${cookieName}`]).access_token
-  headers.append("Authorization", `Bearer ${accessToken}`);
-  const apiResponse = await fetch(
-  `${process.env.NEXT_PUBLIC_API_USER_URL}/auth/me`,
-  { headers }
-  );
-  const data = await apiResponse.json();
-
-  return {
-      props: { user: data.data as IEditUserProfileView['user'] },
+    const apiResponse = await fetch(
+      `${process.env.NEXT_PUBLIC_API_USER_URL}/auth/me`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${accessToken}`
+        }
       }
+    );
+    const { data } = await apiResponse.json();
+
+    return { user: data } as IEditUserProfileView
+  }
+
+  return { user: {} } as IEditUserProfileView
 }
-
-
 
 Home.getLayout = (page) => {
   return (
-      <PrimaryLayout>
-        {page}
-      </PrimaryLayout>
-    );
+    <PrimaryLayout>
+      {page}
+    </PrimaryLayout>
+  );
 };

--- a/pages/dash.tsx
+++ b/pages/dash.tsx
@@ -8,6 +8,7 @@ import CardsCont from '../components/cards/CardsContFree';
 import PrimaryLayout from '../components/layouts/primary/PrimaryLayout';
 import { NextPageWithLayout } from './page';
 import EditUserProfile from './user/edit';
+import { LOGIN_COOKIE } from '../constants/ index';
 
 
 const Home: NextPageWithLayout<IEditUserProfileView> = ({ user }) => {
@@ -69,7 +70,7 @@ export default Home;
 Home.getInitialProps = async (context) => {
   if (context.req?.headers.cookie) {
     const cookies = cookie.parse(context.req.headers.cookie);
-    const { access_token: accessToken } = JSON.parse(cookies[process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME || '']);
+    const { access_token: accessToken } = JSON.parse(cookies[LOGIN_COOKIE || '']);
 
     const apiResponse = await fetch(
       `${process.env.NEXT_PUBLIC_API_USER_URL}/auth/me`,

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -2,92 +2,94 @@ import Cookies from "js-cookie";
 import Router from "next/router";
 import { useState } from "react";
 import apiUserController from "../api/apiUserController";
-// import Cookies from "universal-cookie";
-import PrimaryLayout from "../components/layouts/primary/PrimaryLayout";
 import MainCont from "../components/MainCont/MainCont";
 import QrCard from "../components/QrCard/QrCard";
 import QrWaitingRoom from "../components/QrWaitingRoom/QrWaitingRoom";
-import { NextPageWithLayout } from "./page";
+import PrimaryLayout from "../components/layouts/primary/PrimaryLayout";
 import { GralProps } from "./_app";
+import { NextPageWithLayout } from "./page";
 
-const Qr : NextPageWithLayout<GralProps> = ({linkedWhatsapp}) => {
-    
-    const url = 'https://qrcg-free-editor.qr-code-generator.com/main/assets/images/websiteQRCode_noFrame.png';
+const Qr: NextPageWithLayout<GralProps> = ({ linkedWhatsapp }) => {
 
-    const [queue, setQueue] = useState<number>(0);
+  const url = 'https://qrcg-free-editor.qr-code-generator.com/main/assets/images/websiteQRCode_noFrame.png';
 
-    const logoutBtnStyle = {
-      'width': '100%',
-      'padding': '8px 16px',
-      'borderRadius': '5px',
-      'backgroundColor': '#000',
-      'border': '1px solid var(--amarillo)',
-      'color': 'var(--amarillo)',
-      'cursor': 'pointer',
-      'letterSpacing': '1px',
-    }
+  const [queue, setQueue] = useState<number>(0);
 
-    async function handleLogout(){
-      try {
-          const accessToken = JSON.parse(Cookies.get(process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME)).access_token;
-          const response = await apiUserController.logout(accessToken);
-          if (response.status == 200) {
-              Cookies.remove(process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME);
-              Router.push("/login");
-          }
-      } catch (error: any) {
-          alert(error.response.data.error);
+  const logoutBtnStyle = {
+    'width': '100%',
+    'padding': '8px 16px',
+    'borderRadius': '5px',
+    'backgroundColor': '#000',
+    'border': '1px solid var(--amarillo)',
+    'color': 'var(--amarillo)',
+    'cursor': 'pointer',
+    'letterSpacing': '1px',
+  }
+
+  async function handleLogout() {
+    try {
+      const accessToken = JSON.parse(Cookies.get(process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME)).access_token;
+      const response = await apiUserController.logout(accessToken);
+      if (response.status == 200) {
+        Cookies.remove(process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME);
+        Router.push("/login");
       }
+    } catch (error: any) {
+      alert(error.response.data.error);
     }
+  }
 
 
-    return (
-        <section>
-            <div style={{ 'position': 'absolute', 'top': '5%', 'right':' 5%' }}>
-                <button
-                    onClick={handleLogout}
-                    style={logoutBtnStyle}
-                >LOG OUT</button>
-            </div>
-            {queue == 0 ? (
-                <MainCont width={40}>
-                    <QrCard qr_url={url} linked_whatsapp={linkedWhatsapp}/>
-                </MainCont>
-            ) :
-                <QrWaitingRoom queue={queue}/>
-            }
-        </section>
-    );
+  return (
+    <section>
+      <div style={{ 'position': 'absolute', 'top': '5%', 'right': ' 5%' }}>
+        <button
+          onClick={handleLogout}
+          style={logoutBtnStyle}
+        >LOG OUT</button>
+      </div>
+      {queue == 0 ? (
+        <MainCont width={40}>
+          <QrCard qr_url={url} linked_whatsapp={linkedWhatsapp} />
+        </MainCont>
+      ) :
+        <QrWaitingRoom queue={queue} />
+      }
+    </section>
+  );
 };
 
 Qr.getInitialProps = async (context) => {
   const req = context.req;
 
-//   ~ codigo para testear ~
-
   if (req) {
-    const headers = new Headers({
-      "Content-Type": "application/json",
-    });
-    const cookies = new Cookies(req.headers.cookie);
-    const accessToken = cookies.get(process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME || "").access_token;
-    headers.append("Authorization", `Bearer ${accessToken}`);
+    console.log("asdf", req.headers.cookie);
+    // const cookies = new Cookies(req.headers.cookie);
+    const accessToken = Cookies.get(process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME || "").access_token;
+
     const apiResponse = await fetch(
       `${process.env.NEXT_PUBLIC_API_USER_URL}/ws`,
-      { headers }
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${accessToken}`,
+        }
+      }
     );
-    const data = await apiResponse.json();
-    return { linkedWhatsapp: data.data.connected_whatsapp == 1};
+    const { data } = await apiResponse.json();
+    console.log("asdf", data.connected_whatsapp);
+    return { linkedWhatsapp: data.connected_whatsapp == 1 };
   }
-  return { linkedWhatsapp: false};
+
+  return { linkedWhatsapp: false };
 };
 
 Qr.getLayout = (page) => {
-    return (
-        <PrimaryLayout>
-          {page}
-        </PrimaryLayout>
-      );
-  };
+  return (
+    <PrimaryLayout>
+      {page}
+    </PrimaryLayout>
+  );
+};
 
 export default Qr;

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -61,9 +61,8 @@ const Qr: NextPageWithLayout<GralProps> = ({ linkedWhatsapp }) => {
 };
 
 Qr.getInitialProps = async (context) => {
-  const req = context.req;
-  if (req?.headers.cookie) {
-    const cookies = cookie.parse(req.headers.cookie);
+  if (context.req?.headers.cookie) {
+    const cookies = cookie.parse(context.req.headers.cookie);
     const { access_token: accessToken } = JSON.parse(cookies[process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME || '']);
 
     const apiResponse = await fetch(

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -9,6 +9,7 @@ import QrWaitingRoom from "../components/QrWaitingRoom/QrWaitingRoom";
 import PrimaryLayout from "../components/layouts/primary/PrimaryLayout";
 import { GralProps } from "./_app";
 import { NextPageWithLayout } from "./page";
+import { LOGIN_COOKIE } from '../constants/ index';
 
 const Qr: NextPageWithLayout<GralProps> = ({ linkedWhatsapp }) => {
 
@@ -63,7 +64,7 @@ const Qr: NextPageWithLayout<GralProps> = ({ linkedWhatsapp }) => {
 Qr.getInitialProps = async (context) => {
   if (context.req?.headers.cookie) {
     const cookies = cookie.parse(context.req.headers.cookie);
-    const { access_token: accessToken } = JSON.parse(cookies[process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME || '']);
+    const { access_token: accessToken } = JSON.parse(cookies[LOGIN_COOKIE || '']);
 
     const apiResponse = await fetch(
       `${process.env.NEXT_PUBLIC_API_USER_URL}/ws`,

--- a/pages/qr.tsx
+++ b/pages/qr.tsx
@@ -1,3 +1,4 @@
+import cookie from 'cookie';
 import Cookies from "js-cookie";
 import Router from "next/router";
 import { useState } from "react";
@@ -61,11 +62,9 @@ const Qr: NextPageWithLayout<GralProps> = ({ linkedWhatsapp }) => {
 
 Qr.getInitialProps = async (context) => {
   const req = context.req;
-
-  if (req) {
-    console.log("asdf", req.headers.cookie);
-    // const cookies = new Cookies(req.headers.cookie);
-    const accessToken = Cookies.get(process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME || "").access_token;
+  if (req?.headers.cookie) {
+    const cookies = cookie.parse(req.headers.cookie);
+    const { access_token: accessToken } = JSON.parse(cookies[process.env.NEXT_PUBLIC_LOGIN_COOKIE_NAME || '']);
 
     const apiResponse = await fetch(
       `${process.env.NEXT_PUBLIC_API_USER_URL}/ws`,
@@ -77,8 +76,10 @@ Qr.getInitialProps = async (context) => {
       }
     );
     const { data } = await apiResponse.json();
-    console.log("asdf", data.connected_whatsapp);
-    return { linkedWhatsapp: data.connected_whatsapp == 1 };
+
+    if (data?.connected_whatsapp) {
+      return { linkedWhatsapp: data.connected_whatsapp == 1 };
+    }
   }
 
   return { linkedWhatsapp: false };


### PR DESCRIPTION
Se corrige el mal uso de `js-cookie` en `getInitialProps` del archivo `qr.ts`

Lo que se hizo fue, dejar de usar js-cookie en la carga inicial, ya que al ser server-side no funciona

Saco las cookies del request que me entrega getInitialProps y las parseo con la lib `cookie`. Este me entrega un objeto key-value. Lo necesito parsear de json a string y le hago un destructuring para sacar el `access_token`

_________________

Edit1: También se aplicó la solución a `dash.ts`. Estaría bueno analizar pasar el método a un util, cosa de reciclar el método