### PR TITLE
Fix QR path & refactor middleware

### DIFF
--- a/components/QrCard/QrCard.tsx
+++ b/components/QrCard/QrCard.tsx
@@ -25,7 +25,7 @@ const QrCard: React.FC<IQrCard> = ({ setNotification, notification }) => {
     const handleCall = async (accessToken: string) => {
         const { data: dataConnect } = await apiSenderWhatsappController.isConnected(accessToken)
 
-        if (dataConnect.qrCode) {
+        if (dataConnect?.qrCode) {
             setActiveQr(dataConnect.qrCode)
         }
 

--- a/components/QrCard/QrCard.tsx
+++ b/components/QrCard/QrCard.tsx
@@ -3,16 +3,16 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import apiSenderWhatsappController from '../../api/apiSenderWhatsappController';
 import { LOGIN_COOKIE } from '../../constants/ index';
-import CardTitle from "../cards/CardTitle/CardTitle";
-import Notification, { INotification } from '../Notification/Notification';
 import Loader from '../Loader/Loader';
+import { INotification } from '../Notification/Notification';
+import CardTitle from "../cards/CardTitle/CardTitle";
 
 import OrangeBtn from '../OrangeBtn/OrangeBtn';
 import styles from './QrCard.module.css';
 
 export interface IQrCard {
-    notification : INotification,
-    setNotification : (notification : INotification) => void,
+    notification: INotification,
+    setNotification: (notification: INotification) => void,
 }
 
 
@@ -20,11 +20,16 @@ const QrCard: React.FC<IQrCard> = ({ setNotification, notification }) => {
     const router = useRouter();
     const [loadingQr, setLoadingQr] = useState<boolean>(false);
     const [activeQr, setActiveQr] = useState<string | null>(null);
-    
+
 
     const handleCall = async (accessToken: string) => {
         const { data: dataConnect } = await apiSenderWhatsappController.isConnected(accessToken)
-        return dataConnect?.phoneConnected || dataConnect?.userData;
+
+        if (dataConnect.qrCode) {
+            setActiveQr(dataConnect.qrCode)
+        }
+
+        return dataConnect?.phoneConnected;
     };
 
     const handleIsConnected = () => {
@@ -38,7 +43,7 @@ const QrCard: React.FC<IQrCard> = ({ setNotification, notification }) => {
             } else {
                 router.push("/dash")
             }
-        }, 3000);
+        }, 4000);
     };
 
     const dispatchError = () => {

--- a/components/QrCard/QrCard.tsx
+++ b/components/QrCard/QrCard.tsx
@@ -1,5 +1,4 @@
 import Cookie from 'js-cookie';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import apiSenderWhatsappController from '../../api/apiSenderWhatsappController';
 import { LOGIN_COOKIE } from '../../constants/ index';
@@ -15,7 +14,6 @@ export interface IQrCard {
 }
 
 const QrCard: React.FC<IQrCard> = ({ setNotification, notification }) => {
-    const router = useRouter();
     const [loadingQr, setLoadingQr] = useState<boolean>(false);
     const [activeQr, setActiveQr] = useState<string | null>(null);
 
@@ -27,7 +25,6 @@ const QrCard: React.FC<IQrCard> = ({ setNotification, notification }) => {
             if (dataConnect?.phoneConnected) {
                 setLoadingQr(true);
                 window.location.href= "/dash";
-                //router.push("/dash")
             } else {
                 if (dataConnect?.qrCode !== activeQr) {
                     setActiveQr(dataConnect?.qrCode)

--- a/components/QrCard/QrCard.tsx
+++ b/components/QrCard/QrCard.tsx
@@ -26,7 +26,8 @@ const QrCard: React.FC<IQrCard> = ({ setNotification, notification }) => {
 
             if (dataConnect?.phoneConnected) {
                 setLoadingQr(true);
-                router.push("/dash")
+                window.location.href= "/dash";
+                //router.push("/dash")
             } else {
                 if (dataConnect?.qrCode !== activeQr) {
                     setActiveQr(dataConnect?.qrCode)

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,26 +28,16 @@ export async function middleware(req: NextRequest) {
     );
     const response = await apiResponse.json();
 
-    if(!response) {
+    if (!response) {
       return NextResponse.error();
     }
 
-    if(!response.phoneConnected) {
-      if (req.nextUrl.pathname.startsWith(ROUTES.QR)) {
-        return NextResponse.next();
-      }
-  
-      if (req.nextUrl.pathname.startsWith(ROUTES.DASH) || req.nextUrl.pathname.startsWith(ROUTES.LOGIN)) {
-        return handleRedirect(req, ROUTES.QR);
-      }
-    } else {
-      if (req.nextUrl.pathname.startsWith(ROUTES.DASH)) {
-        return NextResponse.next();
-      }
+    if (response.phoneConnected && (req.nextUrl.pathname.startsWith(ROUTES.QR) || req.nextUrl.pathname.startsWith(ROUTES.LOGIN))) {
+      return handleRedirect(req, ROUTES.DASH);
+    }
 
-      if (req.nextUrl.pathname.startsWith(ROUTES.QR) || req.nextUrl.pathname.startsWith(ROUTES.LOGIN)) {
-        return handleRedirect(req, ROUTES.DASH);
-      }
+    if (!response.phoneConnected && (req.nextUrl.pathname.startsWith(ROUTES.DASH) || req.nextUrl.pathname.startsWith(ROUTES.LOGIN))) {
+      return handleRedirect(req, ROUTES.QR);
     }
   }
 


### PR DESCRIPTION
### Fix QR

- Se corrige el loop de la generación QR

Path
1. Clic generar qr
2. Se genera en el enlace
3. Se genera el QR
4. Se dispara onLoad de la imagen y ocurre el loop

En cada loop pregunta si se conectó

Se conectó:
1. Se muestra loading
2. Se redirige al /dash

No se conectó
1. Se repite el loop

No se conectó pero QR cambió
1. Se dispara el onLoad de la imagen -> se sigue el loop

_______

### Refactor middleware

- En caso de que la respuesta de la API falla, tirará un error
- Se mejoraron los IFs

Casos:

1. No está en el login y No existe la cookie -> redirect /login
2. No está en el login pero existe la cookie -> llamada a la API

Casos luego de llamada a la API
1. API falla -> lanza error
2. Telefono no enlazado WSP y está en /qr -> nada
3. Telefono no enlazado WSP y está en /login ó /dash -> redirect /qr
4. Telefono sí enlazado WSP y está en /dash -> nada
5. Telefono sí enlazado WSP y está en /qr ó /login -> redirect /dash